### PR TITLE
Uplift to latest upstream dugite release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,6 @@ jobs:
         run: git config --global --add safe.directory ""
         shell: bash
       - name: Test
-        run: yarn test
+        run: yarn download-git && yarn test
         env:
           TEST: 1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "dugite",
+  "name": "dugite-no-gpl",
   "version": "2.0.0",
-  "description": "Elegant bindings for Git",
+  "description": "Fork of dugite - Elegant bindings for Git - that skips fetching git binaries post-install",
   "main": "./build/lib/index.js",
   "typings": "./build/lib/index.d.ts",
   "scripts": {
@@ -14,7 +14,6 @@
     "test:slow": "cross-env LOCAL_GIT_DIRECTORY=./git/ jest --runInBand --silent --config ./jest.slow.config.js",
     "test:external": "jest --runInBand --silent --config ./jest.external.config.js",
     "download-git": "node ./script/download-git.js",
-    "postinstall": "node ./script/download-git.js",
     "prettify": "prettier \"{examples,lib,script,test}/**/*.ts\" --write",
     "is-it-pretty": "prettier --check \"{examples,lib,script,test}/**/*.ts\"",
     "update-embedded-git": "node ./script/update-embedded-git.js"
@@ -24,14 +23,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/desktop/dugite.git"
+    "url": "git+https://github.com/theia-ide/dugite.git"
   },
   "author": "GitHub and contributors",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/desktop/dugite/issues"
+    "url": "https://github.com/theia-ide/dugite/issues"
   },
-  "homepage": "https://github.com/desktop/dugite#readme",
+  "homepage": "https://github.com/theia-ide/dugite#readme",
   "dependencies": {
     "progress": "^2.0.3",
     "tar": "^6.1.11"


### PR DESCRIPTION
I rebased Akos' commit, that removes the download of GPL-licensed git upon package install, to v2.0.0 upstream dugite. Also made minimal change so that CI could run, which meant downloading prebuilt git (which we will not include when manually packaging). 